### PR TITLE
Consume `Property` items from local blockchain, render data accordingly on Home page and Details page

### DIFF
--- a/frontend/src/app/_components/PropertiesGrid.tsx
+++ b/frontend/src/app/_components/PropertiesGrid.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
 import PropertyCard from "./PropertyCard"
-import { properties } from "../_fixtures/Properties";
+import { usePropertiesContext } from "../_contexts/state";
 
 export default function PropertiesGrid() {
+    const properties = usePropertiesContext();
+
     return <div className="grid grid-cols-4 gap-4">
         {
             properties.map((property) =>
-                <Link href={`/property/${property.id}`}><PropertyCard key={property.id} {...{ property }} /></Link>
+                <Link key={property.id} href={`/property/${property.id}`}><PropertyCard {...{ property }} /></Link>
             )
         }
     </div>

--- a/frontend/src/app/_contexts/state.tsx
+++ b/frontend/src/app/_contexts/state.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useState } from 'react';
+import { Property } from '../Models';
+import { useContractRead } from 'wagmi';
+import contractData from '../../../../contracts/out/Leasy.sol/Leasy.json';
+
+const PropertiesContext = createContext<Property[]>([]);
+
+type PropertiesContextProviderProps = { children: React.ReactNode };
+
+export function PropertiesContextProvider({ children }: PropertiesContextProviderProps) {
+    const [properties, setProperties] = useState<Property[]>([]);
+
+    const { data, isError, isLoading } = useContractRead({
+        address: process.env.NEXT_PUBLIC_LEASY_CONTRACT_ADDRESS as `0x${string}`,
+        abi: contractData.abi,
+        functionName: 'getProperties',
+        onSuccess(data) {
+            const processedData = (data as Property[]);
+            processedData.shift(); // Removes zero-value at index 0
+            setProperties(processedData);
+        },
+    });
+
+    return <PropertiesContext.Provider value={properties}>{children}</PropertiesContext.Provider>;
+}
+
+export function usePropertiesContext() {
+    return useContext(PropertiesContext);
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { Inter } from 'next/font/google'
 import './globals.css'
@@ -9,21 +9,32 @@ import {
 } from '@rainbow-me/rainbowkit';
 import { configureChains, createConfig, WagmiConfig } from 'wagmi';
 import {
-  mainnet,
-  polygon,
-  optimism,
   arbitrum,
   base,
   baseGoerli,
+  localhost,
+  mainnet,
+  optimism,
+  polygon,
   zora,
 } from 'wagmi/chains';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import Link from 'next/link';
+import { PropertiesContextProvider } from './_contexts/state';
 
 const { chains, publicClient } = configureChains(
-  [mainnet, polygon, optimism, arbitrum, base, baseGoerli, zora],
+  [
+    arbitrum,
+    base,
+    baseGoerli,
+    localhost,
+    mainnet,
+    optimism,
+    polygon,
+    zora
+  ],
   [
     alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID! }),
     publicProvider()
@@ -55,18 +66,20 @@ export default function RootLayout({
       <body className={inter.className + " ms-5 me-5"}>
         <WagmiConfig config={wagmiConfig}>
           <RainbowKitProvider chains={chains}>
-            <header className="flex flex-row mt-5 mb-10">
-              <div>
-                <Link href="/"><h1 className="text-4xl">Leasy 🤝</h1></Link>
-              </div>
-              <div className="ml-auto"><ConnectButton /></div>
-            </header>
+            <PropertiesContextProvider>
+              <header className="flex flex-row mt-5 mb-10">
+                <div>
+                  <Link href="/"><h1 className="text-4xl">Leasy 🤝</h1></Link>
+                </div>
+                <div className="ml-auto"><ConnectButton /></div>
+              </header>
 
-            {children}
+              {children}
 
-            <footer className="mb-5 fixed bottom-0 right-5">
-              Developed by <a className="underline" target="_blank" href="https://github.com/vince-grondin">Roch</a>
-            </footer>
+              <footer className="mb-5 fixed bottom-0 right-5">
+                Developed by <a className="underline" target="_blank" href="https://github.com/vince-grondin">Roch</a>
+              </footer>
+            </PropertiesContextProvider>
           </RainbowKitProvider>
         </WagmiConfig>
       </body>

--- a/frontend/src/app/property/[propertyID]/page.tsx
+++ b/frontend/src/app/property/[propertyID]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { SignerStatus } from "@/app/Models";
-import { properties } from "@/app/_fixtures/Properties"
+import { usePropertiesContext } from "@/app/_contexts/state";
 import { useAccount } from "wagmi";
 
 export type PropertyDetailsParams = {
@@ -12,6 +12,7 @@ export type PropertyDetailsProps = {
 }
 
 export default function PropertyDetails({ params: { propertyID } }: PropertyDetailsProps) {
+    const properties = usePropertiesContext();
     const property = properties.find(it => it.id == propertyID);
     if (!property) throw new Error(`Property ${propertyID} not found!`);
 


### PR DESCRIPTION
Closes #12

## Description
Now that the Leasy contract exposes the `getProperties` method, it can be consumed by the Frontend. This set of changes consists of calling the `getProperties` from the Leasy smart contract deployed at `NEXT_PUBLIC_LEASY_CONTRACT_ADDRESS` using the ABI in Foundry's output folder `contracts/out/` and rendering the `Property` items data accordingly on home page and the details page.

## Changes in this Pull Request
- create the `PropertiesContext`, implement the `PropertiesContextProvider` that uses `useContractRead` to call `getProperties` and returns a provider that exposes the fetches `Property` items to children components
- wrap the root component in `layout.tsx` with the `PropertiesContextProvider` so that `Property` items are available to any components that may needed it
- call `usePropertiesContext()` on the details page to look up the property identified by the `propertyID` instead of using the fixtures array
- call `usePropertiesContext()` on the home page to list the properties
- added `localhost` chain to the wagmi chains config.