### PR TITLE
Implement contract method that takes property ID, potential renters addresses, deposit amount to initiate leasing process

### DIFF
--- a/contracts/src/Leasy.sol
+++ b/contracts/src/Leasy.sol
@@ -8,34 +8,47 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
  * @author Roch
  */
 interface ILeasy is IERC721 {
+    enum PropertyStatus {
+        AVAILABLE, // Default value, keep this first
+        PROCESSING,
+        RENTING
+    }
+
+    enum SignatureStatus {
+        PENDING, // Default value, keep this first
+        APPROVED,
+        DECLINED
+    }
+
+    error PropertyDoesNotExist(uint propertyID);
+    error PropertyNotAvailable(uint propertyID);
+    error SenderNotOwner(uint propertyID);
+
+    event PropertyAdded(uint propertyID);
+    event PropertyLeasingInitiated(uint propertyID);
+
     struct Property {
         uint id;
         string name;
         string fullAddress;
         address owner;
         string leaseAgreementUrl;
-        address[] signers;
-        SignerStatus[] signersStatuses;
+        PropertyStatus status;
+        uint depositAmount;
+        address[] renters;
+        SignatureStatus[] signatureStatuses;
     }
-
-    enum SignerStatus {
-        APPROVED,
-        DECLINED,
-        PENDING
-    }
-
-    event PropertyAdded(uint propertyID);
 
     /**
      * @notice Adds a property.
      * @param _name The name of the property.
      * @param _fullAddress The full address of the property.
-     * @param leaseAgreementUrl The URL to the lease agreement.
+     * @param _leaseAgreementUrl The URL to the lease agreement.
      */
     function addProperty(
         string memory _name,
         string memory _fullAddress,
-        string memory leaseAgreementUrl
+        string memory _leaseAgreementUrl
     ) external returns (uint propertyID);
 
     /**
@@ -43,6 +56,19 @@ interface ILeasy is IERC721 {
      * @return All properties.
      */
     function getProperties() external returns (Property[] memory);
+
+    /**
+     * @notice Initiates the leasing process by setting a deposit amount, an array of potential renters and the date
+     *         the lease ends.
+     * @param _propertyID The ID of the property.
+     * @param _renters The addresses of the potential renters.
+     * @param _depositAmount The requested deposted amount.
+     */
+    function leaseProperty(
+        uint _propertyID,
+        address[] memory _renters,
+        uint _depositAmount
+    ) external returns (bool);
 }
 
 /**
@@ -50,6 +76,8 @@ interface ILeasy is IERC721 {
  * @author Roch
  */
 contract Leasy is ILeasy, ERC721 {
+    using PropertySignatureStatuses for ILeasy.Property;
+
     Property[] internal properties;
 
     constructor(
@@ -86,5 +114,74 @@ contract Leasy is ILeasy, ERC721 {
         returns (Property[] memory)
     {
         return properties;
+    }
+
+    /// @inheritdoc ILeasy
+    function leaseProperty(
+        uint _propertyID,
+        address[] memory _renters,
+        uint _depositAmount
+    )
+        external
+        override
+        propertyExists(_propertyID)
+        propertyAvailable(_propertyID)
+        isOwner(_propertyID)
+        returns (bool)
+    {
+        Property storage property = properties[_propertyID];
+        property.status = PropertyStatus.PROCESSING;
+        property.depositAmount = _depositAmount;
+        property.renters = _renters;
+        property._initializeSignatureStatuses();
+        
+        emit PropertyLeasingInitiated(_propertyID);
+
+        return true;
+    }
+
+    /**
+     * @dev Checks that the property identified by `_propertyID` is in the `properties` array.
+     */
+    modifier propertyExists(uint _propertyID) {
+        if (_propertyID >= properties.length || properties[_propertyID].id == 0)
+            revert PropertyDoesNotExist(_propertyID);
+        _;
+    }
+
+    /**
+     * Checks that the property identified by `_propertyID` has the `PropertyStatus.AVAILABLE` `status`.
+     */
+    modifier propertyAvailable(uint _propertyID) {
+        if (properties[_propertyID].status != PropertyStatus.AVAILABLE)
+            revert PropertyNotAvailable(_propertyID);
+        _;
+    }
+
+    /**
+     * Checks that the sender owns the property identified by `_propertyID.
+     */
+    modifier isOwner(uint _propertyID) {
+        if (_msgSender() != _ownerOf(_propertyID))
+            revert SenderNotOwner(_propertyID);
+        _;
+    }
+}
+
+/**
+ * @title Managers property signature statuses
+ * @author Roch
+ */
+library PropertySignatureStatuses {
+    /**
+     * @dev Initializes the signature statuses of the `_property` property.
+     * @param _property The property for which to initialize signature statuses.
+     */
+    function _initializeSignatureStatuses(
+        ILeasy.Property storage _property
+    ) internal {
+        for (uint i = 0; i < _property.renters.length; i++) {
+            _property.signatureStatuses.push();
+        }
     }
 }


### PR DESCRIPTION
Closes #14

## Description
A property owner can add properties to the contract. This set of changes introduces a new method allowing to designate potential renters (addresses) and specify a deposit amount for the property.

## Changes in this Pull Request
- declare the `leaseProperty` method in `ILeasy` that initiates the leasing process by setting a deposit amount, an array of potential renters and the date the lease ends. Implement it in `Leasy` with the logic below
- validate that the property exists
- validate that the property is available
- validate that the sender is the owner of the property
- set the deposit amount, renters on the property
- initialize the signature statuses: one for each potential renter
- update the status of the property to "processing"
- renamed fields of `Property` and added `depositAmount` and `renters`
- prefixed the `addProperty` method's `leaseAgreementUrl` argument with `_`