### PR TITLE
Render property status in property card and on property details page, render property signers and signature statuses on details page

### DIFF
--- a/frontend/src/app/Models.ts
+++ b/frontend/src/app/Models.ts
@@ -1,13 +1,19 @@
 export type Property = {
     id: number,
     name: string,
-    address: string,
+    fullAddress: string,
     owner: `0x${string}`,
     leaseAgreementUrl: string,
-    signers: `0x${string}`[],
-    signersStatuses: SignerStatus[]
+    status: PropertyStatus,
+    depositAmount: number,
+    renters: `0x${string}`[],
+    signatureStatuses: SignerStatus[]
+}
+
+export enum PropertyStatus {
+    AVAILABLE, PROCESSING, RENTING
 }
 
 export enum SignerStatus {
-    APPROVED, DECLINED
+    PENDING, APPROVED, DECLINED
 }

--- a/frontend/src/app/_components/PropertyCard.tsx
+++ b/frontend/src/app/_components/PropertyCard.tsx
@@ -1,17 +1,18 @@
 import { Property } from "../Models"
+import { PropertyStatusBadge } from "./PropertyStatusBadge"
 
 export type PropertyCardProps = {
     property: Property
 }
 
-export default function PropertyCard({ property: { id, name, address } }: PropertyCardProps) {
-    return <div className="p-6 bg-white rounded-xl shadow-lg flex items-center space-x-4">
-        <div className="">
-            🏠
+export default function PropertyCard({ property: { id, name, fullAddress, status } }: PropertyCardProps) {
+    return <div className="p-6 bg-white rounded-xl shadow-lg">
+        <div className="mb-2">
+            <span className="text-xl font-medium text-black me-2">🏠 {name}</span>
+            <p className="text-slate-500">{fullAddress}</p>
         </div>
         <div>
-            <div className="text-xl font-medium text-black">{name}</div>
-            <p className="text-slate-500">{address}</p>
+            <PropertyStatusBadge status={status} />
         </div>
     </div>
 }

--- a/frontend/src/app/_components/PropertyStatusBadge.tsx
+++ b/frontend/src/app/_components/PropertyStatusBadge.tsx
@@ -1,0 +1,18 @@
+import { PropertyStatus } from "../Models";
+
+export function PropertyStatusBadge({ status }: { status: PropertyStatus }) {
+    switch (status) {
+        case PropertyStatus.AVAILABLE:
+            return <div className="inline-flex items-center px-2 py-1 bg-green-500 border rounded-md font-semibold">
+                <span className="text-white-800 border-green-300">{PropertyStatus[status]}</span>
+            </div>;
+        case PropertyStatus.PROCESSING:
+            return <div className="inline-flex items-center px-2 py-1 bg-blue-500 border rounded-md font-semibold">
+                <span className="text-white-800 border-blue-300">{PropertyStatus[status]}</span>
+            </div>;
+        case PropertyStatus.RENTING:
+            return <div className="inline-flex items-center px-2 py-1 bg-orange-500 border rounded-md font-semibold">
+                <span className="text-white-800 border-green-300">{PropertyStatus[status]}</span>
+            </div>;
+    }
+}

--- a/frontend/src/app/property/[propertyID]/page.tsx
+++ b/frontend/src/app/property/[propertyID]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { SignerStatus } from "@/app/Models";
+import { PropertyStatusBadge } from "@/app/_components/PropertyStatusBadge";
 import { usePropertiesContext } from "@/app/_contexts/state";
 import { useAccount } from "wagmi";
 
@@ -18,41 +19,43 @@ export default function PropertyDetails({ params: { propertyID } }: PropertyDeta
 
     const { address: connectedAddress, isConnecting, isDisconnected } = useAccount();
 
-    const { name, owner, address, leaseAgreementUrl, signers, signersStatuses } = property;
+    const { name, owner, fullAddress, leaseAgreementUrl, renters, signatureStatuses, status } = property;
 
-    function isPdf(documentUrl: string) {
+    function canBeRendered(documentUrl: string) {
         return leaseAgreementUrl.endsWith('.pdf');
     }
 
     return <div>
-        <h1 className="text-3xl block mb-5">🏠 {name}</h1>
-
+        <div className="mb-5">
+            <span className="text-3xl mb-10 me-5">🏠 {name}</span>
+            <PropertyStatusBadge status={status} />
+        </div>
         <h4>👤 Owned by {owner == connectedAddress ? 'you' : owner}</h4>
 
         <span>📍 Located at&nbsp;
-            <a className="underline" target="_blank" href={`https://www.google.com/maps/place/${address}`}>{address}</a>
+            <a className="underline" target="_blank" href={`https://www.google.com/maps/place/${fullAddress}`}>{fullAddress}</a>
         </span>
 
         <hr className="mt-5 mb-5" />
 
         <h2 className="text-2xl mb-2">📃 Lease</h2>
         <h3 className="text-lg">✍️ Signatures</h3>
-        {(!signers || signers.length === 0) &&
+        {(!renters || renters.length === 0) &&
             <div>
-                Lease not sent to any signers.
+                Lease not sent to any renters.
             </div>
         }
-        {signers && signers.length > 0 &&
+        {renters && renters.length > 0 &&
             <ul>
-                {signers.map((address, index) =>
-                    <SignerRow {...{ address, status: signersStatuses[index] || null }} />)
+                {renters.map((address, index) =>
+                    <SignerRow {...{ address, status: signatureStatuses[index] ?? null }} />)
                 }
             </ul>
         }
 
         <h3 className="text-lg mt-5">Agreement</h3>
-        {isPdf(leaseAgreementUrl) && <iframe title="lease" src={leaseAgreementUrl} width={800} height={800} />}
-        {!isPdf(leaseAgreementUrl) && <a className="underline" target="_blank" href={leaseAgreementUrl}>Open 🔗</a>}
+        {canBeRendered(leaseAgreementUrl) && <iframe title="lease" src={leaseAgreementUrl} width={800} height={800} />}
+        {!canBeRendered(leaseAgreementUrl) && <a className="underline" target="_blank" href={leaseAgreementUrl}>Open 🔗</a>}
     </div>
 }
 
@@ -64,9 +67,9 @@ type SignerRowProps = {
 function SignerRow({ address, status }: SignerRowProps) {
     function statusIcon() {
         switch (status) {
-            case SignerStatus.APPROVED: return "✅";
-            case SignerStatus.DECLINED: return "❌";
-            default: return "↗️"
+            case SignerStatus.APPROVED: return <span>✅</span>;
+            case SignerStatus.DECLINED: return <span>❌</span>;
+            case SignerStatus.PENDING: return <span>↗️</span>
         }
     }
 


### PR DESCRIPTION
Closes #16

## Description
A property owner may initiate the leasing process by calling the new `leaseProperty` method of the `Leasy` contract. `Property`s now have a status, a renters array and a signature statuses array. This set of changes consists of rendering a property status in the property card and on property details page, as well as renderering the property signers and signature statuses on details page.

## Changes in this Pull Request
- modify the `Property` model to reflect the field name changes in the contract
- add the `status` and `depositAmount` to the `Property` model
- add the `PropertyStatusBadge` component that renders a colored badge based a property status
- render the property status badge in the property card
- render the property status badge on the property details page
- render the list of renters and their corresponding signature statuses on the property details page

## Screenshots
### Home page - Property status in property card
<img width="1030" alt="Screenshot 2023-12-21 at 11 15 28 AM" src="https://github.com/vince-grondin/base-camp-final-project/assets/561749/68476f9b-f401-47a0-8281-6948a6f1d607">

### Property details page - Available property
<img width="345" alt="Screenshot 2023-12-21 at 11 15 38 AM" src="https://github.com/vince-grondin/base-camp-final-project/assets/561749/83bdf7c5-3dce-4e5c-a395-ca3471b3804c">

### Property details page - Processing property, Signatures requested
<img width="456" alt="Screenshot 2023-12-21 at 11 15 45 AM" src="https://github.com/vince-grondin/base-camp-final-project/assets/561749/6bf3e885-45f9-4388-9384-0f9fe67f7fb9">

### Property details page - Processing property, approved signatures received
<img width="453" alt="Screenshot 2023-12-21 at 11 16 52 AM" src="https://github.com/vince-grondin/base-camp-final-project/assets/561749/bcf5dc0c-c852-4fee-9629-eeffe97801e0">

### Property details page - Processing property, declined signatures received
<img width="477" alt="Screenshot 2023-12-21 at 11 16 58 AM" src="https://github.com/vince-grondin/base-camp-final-project/assets/561749/71524ffb-1520-4b19-9aaf-ad279158cc68">
