### PR TITLE
Replace the concept of renters and applicants with the concept of bookings

### DIFF
--- a/frontend/src/app/Models.ts
+++ b/frontend/src/app/Models.ts
@@ -1,3 +1,14 @@
+export type Booking = {
+    id: number,
+    booker: `0x${string}`,
+    propertyID: number;
+    depositAmount: number;
+    dates: string[];
+    status: BookingStatus;
+}
+
+export enum BookingStatus { REQUESTED, ACCEPTED }
+
 export type Property = {
     id: number,
     name: string,
@@ -5,11 +16,7 @@ export type Property = {
     owner: `0x${string}`,
     picturesUrls: string,
     status: PropertyStatus,
-    depositAmount: number,
-    applicants: `0x${string}`[],
-    applicantsDates: string[],
-    renters: `0x${string}`[],
-    rentersDates: string[],
+    depositAmount: number
 }
 
 export enum PropertyStatus { INACTIVE, AVAILABLE }


### PR DESCRIPTION
Closes #27

## Description
The schemas and concepts used to distinguish between pending applicants and approved applications wasn't well-thought through and was getting difficult to manage. Rethought the concept by replacing them with the simple concept booking: a user may request a booking for certain dates and it may be approved by the owner. Creating applicants and transitioning them to renters wasn't going to scale, especially knowing that one same user can request several bookings.

## Changes in this Pull Request
- introduce the `Booking` struct and `BookingStatus` enum. It has an ID, a booker, a property ID, a deposit amount an array of string dates and a status
- refactored `inquireStay` into `requestBooking` and `selectApplicant` into `acceptBooking`, the latter being much more simple now as it simply consists of updating a booking status (not need to transfer applicant to renter anymore)
- modified the Frontend model accordingly and fetching bookings on Property Details page load

## Screenshots
### Property with a pending booking and an accepted booking, owner view
![Screenshot 2024-01-04 at 12 57 28 PM](https://github.com/vince-grondin/base-camp-final-project/assets/561749/2b7250fd-ca82-42f9-93df-9ae33e699fd4)
