### PR TITLE
Support navigation to property details page directly via URL

### DIFF
--- a/contracts/src/Leasy.sol
+++ b/contracts/src/Leasy.sol
@@ -100,6 +100,14 @@ interface ILeasy is IERC721 {
     ) external returns (Booking[] memory propertyBookings);
 
     /**
+     * @notice Gets the property identified by the supplied `_propertyID`.
+     * @param _propertyID The ID of the property.
+     */
+    function getProperty(
+        uint _propertyID
+    ) external view returns (Property memory);
+
+    /**
      * @notice Gets all properties.
      * @return All properties.
      */
@@ -135,6 +143,8 @@ contract Leasy is ILeasy, ERC721 {
     ) external override returns (uint propertyID) {
         // TODO Support status param to activate when adding, support deposit amount to set deposit when adding
         propertyID = properties.length;
+        uint propertyIndex = properties.length;
+        
         _mint(_msgSender(), propertyID);
 
         Property storage property = properties.push();
@@ -143,6 +153,8 @@ contract Leasy is ILeasy, ERC721 {
         property.fullAddress = _fullAddress;
         property.picturesUrls = _picturesUrls;
         property.owner = _msgSender();
+
+        propertyIndexes[propertyID] = propertyIndex;
 
         emit PropertyAdded(propertyID);
     }
@@ -244,6 +256,19 @@ contract Leasy is ILeasy, ERC721 {
         for (uint i = 0; i < bookingIDs.length; i++) {
             propertyBookings[i] = bookings[bookingsIndexes[bookingIDs[i]]];
         }
+    }
+
+    /// @inheritdoc ILeasy
+    function getProperty(
+        uint _propertyID
+    )
+        external
+        view
+        override
+        propertyExists(_propertyID)
+        returns (Property memory)
+    {
+        return properties[propertyIndexes[_propertyID]];
     }
 
     /// @inheritdoc ILeasy

--- a/contracts/test/Leasy.t.sol
+++ b/contracts/test/Leasy.t.sol
@@ -363,6 +363,60 @@ contract LeasyTest is Test {
     }
 
     /**
+     * @dev Verifies that calling `getProperty` when the property does not exist reverts with a `PropertyDoesNotExist`
+     *      error
+     * @param _owner The address of the user who added a property.
+     * @param _retriever The address of the user getting an inexisting property.
+     */
+    function test_GivenPropertyNotExist_WhenGettingProperty_ThenPropertyDoesNotExistRevert(
+        address _owner,
+        address _retriever,
+        uint _inexistingPropertyID
+    ) public {
+        vm.assume(_owner != address(0));
+        vm.assume(_retriever != address(0) && _retriever != _owner);
+        vm.assume(
+            _inexistingPropertyID > 0 &&
+                _inexistingPropertyID != propertyFixture1.id
+        );
+
+        vm.startPrank(_owner);
+        _addProperty(propertyFixture1);
+        vm.stopPrank();
+
+        vm.startPrank(_retriever);
+
+        _expectPropertyDoesNotExistRevert(_inexistingPropertyID);
+
+        leasy.getProperty(_inexistingPropertyID);
+    }
+
+    /**
+     * @dev Verifies that calling `getProperty` for a property that exists succeeds.
+     * @param _owner The address of the user who added a property.
+     * @param _retriever The address of the user getting an inexisting property.
+     */
+    function test_GivenPropertyExists_WhenGettingProperty_ThenSuccess(
+        address _owner,
+        address _retriever
+    ) public {
+        vm.assume(_owner != address(0));
+        vm.assume(_retriever != address(0) && _retriever != _owner);
+
+        vm.startPrank(_owner);
+        _addProperty(propertyFixture1);
+        vm.stopPrank();
+
+        vm.startPrank(_retriever);
+
+        ILeasy.Property memory result = leasy.getProperty(propertyFixture1.id);
+
+        ILeasy.Property memory expectedProperty = propertyFixture1;
+        expectedProperty.owner = _owner;
+        _assertEqProperty(result, expectedProperty);
+    }
+
+    /**
      * @dev Helper function that delegates to `leasy#addProperty`.
      * @param _property The property to add.
      */

--- a/frontend/src/app/property/[propertyID]/page.tsx
+++ b/frontend/src/app/property/[propertyID]/page.tsx
@@ -50,7 +50,7 @@ export default function PropertyDetails({ params: { propertyID } }: PropertyDeta
         },
     });
 
-    if (property === null) return <div>Loading</div>
+    if (property === null) return <div>Loading...</div>
 
     const {
         name,


### PR DESCRIPTION
Closes #30

## Description
Users can currently navigate to a property details page only from the dashboard.

This set of changes consists of consuming the path parameter and to get the property by ID on page load so that users can also directly navigate to a property details page via URL (eg. `/property/1`).

## Changes in this Pull Request
- add `getProperty` Leasy contract method to get property by ID
- modify the `PropertyDetails` component to fetch the property by ID from the contract instead of getting it from the properties context