### PR TITLE
Add LeasyStay contract with saveStay method, integrate new endBooking method in Leasy contract to mint stay for booker

### DIFF
--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,1 +1,2 @@
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@src/=src/

--- a/contracts/src/Leasy.sol
+++ b/contracts/src/Leasy.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/interfaces/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "./LeasyStay.sol";
+import "@src/LeasyStay.sol";
 
 /**
  * @title Main contract hosting logic for Leasy, a system allowing to mint properties and lease them.
@@ -263,8 +263,8 @@ contract Leasy is ILeasy, ERC721 {
         isOwnerByBookingID(_bookingID)
         returns (bool)
     {
-        Booking memory booking = bookings[bookingsIndexes[_bookingID]];
-        booking.status = BookingStatus.COMPLETED;
+        Booking storage booking = bookings[bookingsIndexes[_bookingID]];
+        booking.status = BookingStatus.ENDED;
 
         leasyStay.saveStay(_bookingID, booking.booker, booking.propertyID, booking.dates);
 

--- a/contracts/src/LeasyStay.sol
+++ b/contracts/src/LeasyStay.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/interfaces/IERC721.sol";
+
+/**
+ * @title Contract maintaining records of stays at properties maintained by the `Leasy` contract.
+ * @author Roch
+ */
+interface ILeasyStay is IERC721 {
+    event StaySaved(uint stayID, address booker, uint propertyID);
+
+    struct Stay {
+        uint id;
+        uint bookingID;
+        address booker;
+        uint propertyID;
+        string[] dates;
+    }
+
+    /**
+     * @notice Mints a record as a proof a user completed their stay at the property identified by the supplied
+     *         `_propertyID`.
+     * @param _bookingID The identifier of the booking completed in the `Leasy` contract.
+     * @param _booker The address of the user who completed the booking.
+     * @param _propertyID The identifier of the property where the user completed their stay.
+     * @param _dates The dates the user stayed at the property.
+     */
+    function saveStay(
+        uint _bookingID,
+        address _booker,
+        uint _propertyID,
+        string[] memory _dates
+    ) external returns (bool);
+}
+
+contract LeasyStay is ILeasyStay, ERC721 {
+    Stay[] internal stays;
+    mapping (uint stayID => uint stayIndex) internal stayIndexes;
+    mapping (address owner => Stay[] userStays) internal userStays;
+
+    constructor(
+        string memory _name,
+        string memory _symbol
+    ) ERC721(_name, _symbol) {
+        // Avoid 0 index
+        stays.push();
+    }
+
+    /// @inheritdoc ILeasyStay
+    function saveStay(
+        uint _bookingID,
+        address _booker,
+        uint _propertyID,
+        string[] memory _dates
+    ) external override returns (bool) {
+        // TODO Revert if any of the dates are in the future?
+
+        uint stayID = stays.length;
+
+        _mint(_booker, stayID);
+
+        stays.push(Stay({
+            id: stayID,
+            bookingID: _bookingID,
+            booker: _booker,
+            propertyID: _propertyID,
+            dates: _dates
+        }));
+
+        emit StaySaved(stayID, _booker, _propertyID);
+
+        return true;
+    }
+}

--- a/contracts/test/Leasy.t.sol
+++ b/contracts/test/Leasy.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import "forge-std/Test.sol";
 import "../src/Leasy.sol";
+import "../src/LeasyStay.sol";
 
 /**
  * @title Verifies the behavior of the Leasy contract.
@@ -10,6 +11,7 @@ import "../src/Leasy.sol";
  */
 contract LeasyTest is Test {
     Leasy private leasy;
+    LeasyStay private leasyStay;
 
     Leasy.Property private defaultProperty;
 
@@ -23,7 +25,15 @@ contract LeasyTest is Test {
     event PropertyActivated(uint propertyID);
 
     function setUp() public {
-        leasy = new Leasy("TEST_NAME", "TEST_SYMBOL");
+        leasyStay = new LeasyStay(
+            "LEASY_STAY_TEST_NAME",
+            "LEASY_STAY_TEST_SYMBOL"
+        );
+        leasy = new Leasy(
+            "LEASY_TEST_NAME",
+            "LEASY_TEST_SYMBOL",
+            address(leasyStay)
+        );
         _initializeTestFixtures();
     }
 

--- a/frontend/src/app/Models.ts
+++ b/frontend/src/app/Models.ts
@@ -7,7 +7,7 @@ export type Booking = {
     status: BookingStatus;
 }
 
-export enum BookingStatus { REQUESTED, ACCEPTED }
+export enum BookingStatus { REQUESTED, ACCEPTED, ENDED }
 
 export type Property = {
     id: number,


### PR DESCRIPTION
Closes #45

## Description
Once a guest completes a stay, the owner can now end the booking and the booker is rewarded with a "stay" reward as a proof they stayed at the property for the dates of the booking.

**Due to time constraints, tests are omitted with this PR and will be backfilled in subsequent PR(s)**

## Changes in this Pull Request
- add `ILeasyStay` and `LeasyStay` to manage "stay" rewards for bookers and completed their stay at a property
- add the address of the deployed `LeasyStay` contract as a constructor argument to `Leasy` and a field in the `Leasy` contract to be able to invoke methods of the `LeasyStay` contract from the `Leasy` contract
- declare the `endBooking` method in `ILeasy` and implement it in `Leasy`: the implementation updates the booking status to `COMPLETED` and invokes `LeasyStay#saveStay` to reward the booker with a "stay" reward