### PR TITLE
Add getMyStays to LeasyStay contract, link to new /stays route for each booking and stays page

### DIFF
--- a/contracts/src/Leasy.sol
+++ b/contracts/src/Leasy.sol
@@ -138,7 +138,7 @@ contract Leasy is ILeasy, ERC721 {
     mapping(uint bookingID => uint bookingIndex) internal bookingsIndexes;
     mapping(uint propertyID => uint[] bookingIDs) propertyBookingIDs;
 
-    LeasyStay leasyStay;
+    ILeasyStay leasyStay;
 
     constructor(
         string memory _name,
@@ -148,7 +148,7 @@ contract Leasy is ILeasy, ERC721 {
         // Avoid 0 index
         properties.push();
         bookings.push();
-        leasyStay = LeasyStay(_leasyStay);
+        leasyStay = ILeasyStay(_leasyStay);
     }
 
     /// @inheritdoc ILeasy

--- a/docs/docs/4-Quick Start.md
+++ b/docs/docs/4-Quick Start.md
@@ -1,39 +1,60 @@
 # Quick Start
 
 ## Smart Contracts
+
 1. Start local Ethereum node
+
 ```shell
 cd contracts; anvil
 ```
 
-2. Deploy Leasy contract to local Ethereum node
+2. a. Deploy `LeasyStay` contract to local Ethereum node and save the address after `Deployed to: `
+
 ```shell
-forge create src/Leasy.sol:Leasy --private-key <private_key_from_anvil_output> --constructor-args <erc-721-token-name> <erc-721-token-symbol>
+forge create src/LeasyStay.sol:LeasyStay --private-key <private_key_from_anvil_output> --constructor-args LEASY_STAY_LOCAL_1_NAME LEASY_STAY_LOCAL_1_SYMBOL
 ```
 
-3. Copy address of deployed contract to clipboard
+2. b. Deploy `Leasy` contract to local Ethereum node and save the address after `Deployed to: `
 
-4. Build
+```shell
+forge create src/Leasy.sol:Leasy --private-key <private_key_from_anvil_output> --constructor-args LEASY_LOCAL_1_NAME LEASY_LOCAL_1_SYMBOL <leasy stay contract address from 2. a.>
+```
+
+3. Build
+
 ```shell
 $ forge build
 ```
 
-5. Navigate to Remix IDE
+4. Navigate to Remix IDE
 
-6. Click on `Deploy & run transactions`, select `Dev - Foundry Provider`, enter contract address from output of step 3.
-   in `At Address` field and interact with contract
+5. Create project and add `Leasy.sol` and `LeasyStay.sol` under `contracts`, compile them
+
+6. Click on `Deploy & run transactions`, select `Dev - Foundry Provider`,
+
+7. Select `LeasyStay` from the `CONTRACT` dropdown, enter the address from 2. a. in `At Address` field and click on `At Address`
+
+8. Select `Leasy` from the `CONTRACT` dropdown, enter the address from 2. b. in `At Address` field and click on `At Address`
+
+At this point, you may now interact with the contracts in Remix IDE.
 
 ## Frontend
+
 1. Start Frontend
+
 ```shell
 cd frontend; npm i; npm run dev
 ```
 
 2. Create `.env.local` file with properties:
+
 ```
 NEXT_PUBLIC_ALCHEMY_ID=<your alchemy ID>
-NEXT_PUBLIC_LEASY_CONTRACT_ADDRESS=<address of contract from step 3.>
+NEXT_PUBLIC_LEASY_CONTRACT_ADDRESS=<address of contract from step 2. b.>
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=<your wallet connect project ID>
 ```
 
 2. Navigate to http://localhost:3000
+
+At this point, you may now interact with the dApp which makes calls to the deployed `Leasy` and `LeasyStay` smart
+contracts.

--- a/docs/docs/7-Base Bootcamp Presentation/3-Flow and Components.md
+++ b/docs/docs/7-Base Bootcamp Presentation/3-Flow and Components.md
@@ -87,7 +87,7 @@ classDiagram
     ERC721 <|-- Leasy : inherits
     Leasy --o Booking : uses (one-to-many)
     Leasy --o Property : uses (one-to-many)
-    Leasy --* LeasyStay : uses (one-to-one)
+    Leasy --* ILeasyStay : uses (one-to-one)
 
     IERC721 <|-- ILeasyStay : inherits
     ILeasyStay <|-- LeasyStay : implements

--- a/docs/docs/7-Base Bootcamp Presentation/3-Flow and Components.md
+++ b/docs/docs/7-Base Bootcamp Presentation/3-Flow and Components.md
@@ -1,6 +1,7 @@
 # Components and Flow
 
 ## Flow
+
 <details>
 ```mermaid
 ---
@@ -27,6 +28,7 @@ classDiagram
         +activateProperty(uint _propertyID, uint _depositAmount) external returns (bool)
         +requestBooking(uint _propertyID, string[] memory _dates) external payable returns (bool)
         +acceptBooking(uint _bookingID) external returns (bool)
+        +endBooking(uint _bookingID) external returns (bool)
         +getBookings(uint _propertyID) external returns (Booking[] memory propertyBookings)
         +getProperty(uint _propertyID) external view returns (Property memory)
         +getProperties() external returns (Property[] memory)
@@ -62,11 +64,34 @@ classDiagram
         +uint depositAmount
     }
 
+    class ILeasyStay {
+        +getMyStays() external returns (Stay[] memory _myStays)
+        +saveStay(uint _bookingID, address _booker, uint _propertyID, string[] memory _dates) external returns (bool)
+    }
+    <<interface>> ILeasy
+
+    class LeasyStay {
+        -Stay[] stays
+    }
+
+    class Stay {
+        +uint id
+        +uint bookingID
+        +address booker
+        +uint propertyID
+        +string[] dates
+    }
+
     IERC721 <|-- ILeasy : inherits
     ILeasy <|-- Leasy : implements
     ERC721 <|-- Leasy : inherits
     Leasy --o Booking : uses (one-to-many)
     Leasy --o Property : uses (one-to-many)
+    Leasy --* LeasyStay : uses (one-to-one)
 
+    IERC721 <|-- ILeasyStay : inherits
+    ILeasyStay <|-- LeasyStay : implements
+    ERC721 <|-- LeasyStay : inherits
+    LeasyStay --o Stay : uses (one-to-many)
 ```
 </details>

--- a/frontend/src/app/Models.ts
+++ b/frontend/src/app/Models.ts
@@ -20,3 +20,11 @@ export type Property = {
 }
 
 export enum PropertyStatus { INACTIVE, AVAILABLE }
+
+export type Stay = {
+    id: number,
+    bookingID: number,
+    booker: `0x${string}`,
+    propertyID: number,
+    dates: string[];
+}

--- a/frontend/src/app/_components/Bookings.tsx
+++ b/frontend/src/app/_components/Bookings.tsx
@@ -3,6 +3,7 @@ import { Booking, BookingStatus, Property } from "@/app/Models";
 import { useState } from "react";
 import { useContractRead } from "wagmi";
 import contractData from '../../../../contracts/out/Leasy.sol/Leasy.json';
+import Link from "next/link";
 
 export type BookingsSectionProps = {
     propertyID: number
@@ -10,8 +11,9 @@ export type BookingsSectionProps = {
 
 export default function BookingsSection({ propertyID }: BookingsSectionProps) {
     const [bookings, setBookings] = useState<Booking[]>([]);
-    const pendingBookings = bookings.filter(({ status }) => status === BookingStatus.REQUESTED);
     const acceptedBookings = bookings.filter(({ status }) => status === BookingStatus.ACCEPTED);
+    const endedBookings = bookings.filter(({ status }) => status === BookingStatus.ENDED);
+    const pendingBookings = bookings.filter(({ status }) => status === BookingStatus.REQUESTED);
 
     useContractRead({
         address: process.env.NEXT_PUBLIC_LEASY_CONTRACT_ADDRESS as `0x${string}`,
@@ -22,6 +24,7 @@ export default function BookingsSection({ propertyID }: BookingsSectionProps) {
             console.log(error);
         },
         onSuccess(data) {
+            console.log(data);
             setBookings(data as Booking[]);
         },
         watch: true
@@ -34,9 +37,7 @@ export default function BookingsSection({ propertyID }: BookingsSectionProps) {
         }
         {pendingBookings.length > 0 &&
             <ul>
-                {pendingBookings.map(({ id, booker, dates }, index) =>
-                    <li key={index}>Booking #{id.toString()}: {booker} - {dates.reduce((acc: string, curr: string) => `${acc}, ${curr}`)}</li>
-                )}
+                {pendingBookings.map((booking, index) => <BookingRow key={index} {...booking} />)}
             </ul>
         }
 
@@ -44,10 +45,25 @@ export default function BookingsSection({ propertyID }: BookingsSectionProps) {
         {acceptedBookings.length == 0 && <div><span className="italic">No accepted bookings.</span></div>}
         {acceptedBookings.length > 0 &&
             <ul>
-                {acceptedBookings.map(({ id, booker, dates }, index) =>
-                    <li key={index}>Booking #{id.toString()}: {booker} - {dates.reduce((acc: string, curr: string) => `${acc}, ${curr}`)}</li>
-                )}
+                {acceptedBookings.map((booking, index) => <BookingRow key={index} {...booking} />)}
+            </ul>
+        }
+
+        <h3 className="text-lg mt-2">✅✅ Ended Bookings</h3>
+        {endedBookings.length == 0 && <div><span className="italic">No completed bookings.</span></div>}
+        {endedBookings.length > 0 &&
+            <ul>
+                {endedBookings.map((booking, index) => <BookingRow key={index} {...booking} />)}
             </ul>
         }
     </div>
+}
+
+function BookingRow({ id, booker, dates }: Booking) {
+    return <li>
+        Booking #{id.toString()}:&nbsp;
+        <Link className="underline" href={`/stays/${booker}`}>{booker}</Link>&nbsp;
+        -&nbsp;
+        {dates.reduce((acc: string, curr: string) => `${acc}, ${curr}`)}
+    </li>
 }

--- a/frontend/src/app/_contexts/state.tsx
+++ b/frontend/src/app/_contexts/state.tsx
@@ -17,6 +17,7 @@ export function PropertiesContextProvider({ children }: PropertiesContextProvide
         onSuccess(data) {
             setProperties(data as Property[]);
         },
+        watch: true
     });
 
     return <PropertiesContext.Provider value={properties}>{children}</PropertiesContext.Provider>;

--- a/frontend/src/app/stays/[userAddress]/page.tsx
+++ b/frontend/src/app/stays/[userAddress]/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useState } from "react";
+import { useAccount, useContractRead } from "wagmi";
+import contractData from '../../../../../contracts/out/LeasyStay.sol/LeasyStay.json';
+import { Stay } from "@/app/Models";
+
+export type StaysGridParams = {
+    userAddress: `0x${string}`
+}
+
+export type StaysGridProps = {
+    params: StaysGridParams
+}
+
+export default function StaysGrid({ params: { userAddress } }: StaysGridProps) {
+    const [stays, setStays] = useState<Stay[]>([]);
+    const { address: connectedAddress } = useAccount();
+    const [isFetching, setIsFetching] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    useContractRead({
+        address: process.env.NEXT_PUBLIC_LEASY_STAY_CONTRACT_ADDRESS as `0x${string}`,
+        abi: contractData.abi,
+        functionName: 'getMyStays',
+        onError(error) {
+            console.log(error);
+            setErrorMessage(`Unable to retrieve stays for ${connectedAddress}!`);
+            setIsFetching(false);
+        },
+        onSuccess(data) {
+            console.log(data);
+            setStays(data as Stay[]);
+            setIsFetching(false);
+        },
+        account: userAddress
+    });
+
+    if (isFetching === null) return <div>Retrieving stays...</div>
+    if (errorMessage) return <div className="text-red-600">{errorMessage}</div>
+
+    return <div>
+        <div className="mb-5">
+            <span className="text-4xl me-5">Your Stays Rewards</span>
+        </div>
+
+        {stays.length == 0 && <div><span className="italic">No stay rewards. Book and complete a stay a property to get rewards!</span></div>
+        }
+        {stays.length > 0 &&
+            <div className="grid grid-cols-4 gap-4">
+                {
+                    stays.map(({ id, bookingID, propertyID, dates }) =>
+                        <div key={id} className="p-6 bg-white rounded-xl shadow-lg text-zinc-600">
+                            ID: {id.toString()}
+                            <br />
+                            Booking ID: {bookingID.toString()}
+                            <br />
+                            Property ID: {propertyID.toString()}
+                            <br />
+                            Dates: #{dates.reduce((acc: string, curr: string) => `${acc}, ${curr}`)}
+                        </div>
+                    )
+                }
+            </div>
+        }
+    </div>
+}


### PR DESCRIPTION
Closes #47

## Description
Now that users are reward with stay rewards after they complete a booking/stay, this set of changes consists of adding a method to the `LeasyStay` contract to get the stays and integrating with it in a new Frontend route & page that renders the stays rewards for a users.

**Due to time constraints, tests for these changes will be implemented in subsequent PR(s).**

## Changes in this Pull Request
- declare `getMyStays` in `ILeasyStay`, implement it in `LeasyStay` by storing the index of each registered stay in the `userStays` and creating the user's stays array when invoked
- updated the `Quick Start` guide with information about how to deploy and use both contracts
- added the `/stays/{userAddress}` page that invokes the `LeasyStay#getMyStays` contract and renders the user's stays rewards, if any

## Screenshots
### Updated Property Details page with links to booker's stays page - Owner view
![Screenshot 2024-01-12 at 10 15 21 AM](https://github.com/vince-grondin/base-camp-final-project/assets/561749/6ba6a61f-290f-4c7c-a88f-53709a547ecf)

### Stays page after a user has received stays rewards
![Screenshot 2024-01-12 at 10 16 18 AM](https://github.com/vince-grondin/base-camp-final-project/assets/561749/b0fa6b2c-f685-46b1-83d5-866934ae20f8)

### Stays page for users without any stays rewards
![Screenshot 2024-01-12 at 10 16 51 AM](https://github.com/vince-grondin/base-camp-final-project/assets/561749/548cf816-7b74-4b49-ae6f-36eef9163cd3)
